### PR TITLE
Add context-senitivity to userscript.sh

### DIFF
--- a/uzbl/data/scripts/userscript.sh
+++ b/uzbl/data/scripts/userscript.sh
@@ -2,11 +2,6 @@
 
 do_scripts() {
 	scripts_dir="$1"
-	if [ -z $2 ]; then
-		current_context="all"
-	else
-		current_context="$2" # should be document-end or document-start or all
-	fi
 	IFS="
 	"
 	# Loop over all userscripts in the directory
@@ -39,7 +34,7 @@ do_scripts() {
 		for RUN_AT in `echo "$META" | grep "^\s*\/\/\s*@run-at"`; do
 			THIS_RUNS_AT="`echo "$RUN_AT" | sed -e 's/^\s*\/\/\s*@run-at\s*//' -e 's/\./\\\\./g' -e 's/\*/.*/g' -e 's/[\r\n]//g'`"
 		done
-		if [ "$current_context" != "all" -a "$THIS_RUNS_AT" != "$current_context" ]; then
+		if [ "$current_context" != "document-any" -a "$THIS_RUNS_AT" != "$current_context" ]; then
 			SHOULD_RUN=false
 		fi
 
@@ -51,4 +46,5 @@ do_scripts() {
 }
 
 # TODO search XDG_DATA_DIRS
-do_scripts "`dirname $0`/../userscripts" "$1"
+current_context="${1-document-any}"
+do_scripts "`dirname $0`/../userscripts"

--- a/uzbl/data/scripts/userscript.sh
+++ b/uzbl/data/scripts/userscript.sh
@@ -2,6 +2,11 @@
 
 do_scripts() {
 	scripts_dir="$1"
+	if [ -z $2 ]; then
+		current_context="all"
+	else
+		current_context="$2" # should be document-end or document-start or all
+	fi
 	IFS="
 	"
 	# Loop over all userscripts in the directory
@@ -9,6 +14,7 @@ do_scripts() {
 		SCRIPT="`readlink -en "$SCRIPT"`"
 		# Extract metadata chunk
 		META="`sed -ne '/^\s*\/\/\s*==UserScript==\s*$/,/^\s*\/\/\s*==\/UserScript==\s*$/p' "$SCRIPT"`"
+		RUNS_AT=document-end # By default, run only on document end
 		SHOULD_RUN=false # Assume this script will not be included
 		# Loop over all include rules
 		for INCLUDE in `echo "$META" | grep "^\s*\/\/\s*@include"`; do
@@ -28,6 +34,15 @@ do_scripts() {
 				break
 			fi
 		done
+		# Find run-at code
+		THIS_RUNS_AT="document-end" # by default, scripts run after page load
+		for RUN_AT in `echo "$META" | grep "^\s*\/\/\s*@run-at"`; do
+			THIS_RUNS_AT="`echo "$RUN_AT" | sed -e 's/^\s*\/\/\s*@run-at\s*//' -e 's/\./\\\\./g' -e 's/\*/.*/g' -e 's/[\r\n]//g'`"
+		done
+		if [ "$current_context" != "all" -a "$THIS_RUNS_AT" != "$current_context" ]; then
+			SHOULD_RUN=false
+		fi
+
 		# Run the script
 		if [ $SHOULD_RUN = true ]; then
 			echo "script '$SCRIPT'" >> "$UZBL_FIFO"
@@ -36,4 +51,4 @@ do_scripts() {
 }
 
 # TODO search XDG_DATA_DIRS
-do_scripts "`dirname $0`/../userscripts"
+do_scripts "`dirname $0`/../userscripts" "$1"


### PR DESCRIPTION
Adds an argument that can be passed to userscript.sh, specifying whether the
current context is document-start or document-end.  Then within the uzbl config
the following can be done:

```
@on_event   LOAD_COMMIT    spawn @scripts_dir/userscripts.sh document-start
@on_event   LOAD_FINISH    spawn @scripts_dir/userscripts.sh document-end
```

Which allows userscripts to be run when they want.  If the argument is ommited,
then userscript.sh runs on all scripts, preserving current behavior.

---

This feature appears to be a standard respected by Greasemonkey (see http://wiki.greasespot.net/Metadata_Block#.40run-at ).  Certainly I've noticed a number of scripts on userscripts.org using it
