### PR TITLE
Explicitly require userscripts to end with .user.js

### DIFF
--- a/uzbl/data/scripts/userscript.sh
+++ b/uzbl/data/scripts/userscript.sh
@@ -5,7 +5,7 @@ do_scripts() {
 	IFS="
 	"
 	# Loop over all userscripts in the directory
-	for SCRIPT in `grep -lx "\s*//\s*==UserScript==\s*" "$scripts_dir"/*`; do
+	for SCRIPT in `grep -lx "\s*//\s*==UserScript==\s*" "$scripts_dir"/*.user.js`; do
 		SCRIPT="`readlink -en "$SCRIPT"`"
 		# Extract metadata chunk
 		META="`sed -ne '/^\s*\/\/\s*==UserScript==\s*$/,/^\s*\/\/\s*==\/UserScript==\s*$/p' "$SCRIPT"`"


### PR DESCRIPTION
This prevents the situation where usercript a.user.js is edited, creating
backup a.user.js~, and each userscript is run, most likely with unintended
results.

---

Feel free to reject this one, I simply found it useful when I wanted to keep versioned userscripts for testing.
